### PR TITLE
Fix typo in Tag.occurrences

### DIFF
--- a/api-documentation.md
+++ b/api-documentation.md
@@ -341,7 +341,7 @@ Return a list of information and settings for the Shaarli instance.
 
 ### Tag
 + name: Tutorial (string, required) - Name of the tag
-+ occurences: 47 (number, optional) - Number of links using this tag
++ occurrences: 47 (number, optional) - Number of links using this tag
 
 ### TagRequest
 + name: music (string, required) - Name of the tag


### PR DESCRIPTION
While working on an Shaarli iOS App, I noticed this typo in the `Tag` structure documentation. This typo only affects the documentation and is not present in the API return value.